### PR TITLE
<fix> : 아이템 검색창에서 검색어가 잘 매칭되지 않던 버그 픽스

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -28,8 +28,17 @@ export const useMainStore = defineStore('main', {
     /** 2) 검색어에 매칭되는 후보 추출 (optional helper) */
     searchItemCandidates(query) {
       if (!query) return []
-      const q = query.toLowerCase()
-      return this.allItems.filter(i =>i.nameKorean.includes(q)).slice(0, 10)
+      const q = query.toLowerCase().replace(/\s+/g, '')
+
+      return this.allItems.filter(item => {
+        // Remove spaces from item name and create a normalized version
+        const normalizedName = item.nameKorean.replace(/\s+/g, '').toLowerCase()
+        // Also create English-only version for matching English prefixes
+        const englishPrefix = item.nameKorean.match(/^[a-zA-Z]+/)?.[0]?.toLowerCase() || ''
+
+        return normalizedName.includes(q) || // Match normalized name
+            (englishPrefix && q.startsWith(englishPrefix)) // Match English prefix
+      }).slice(0, 10)
     },
 
     /** 3) 아이콘 URL 반환 헬퍼 */


### PR DESCRIPTION
- 영어 검색시 매칭이 되지 않던 버그 픽스 및 대소문자 구별하지않도록
- 공백이 있는 아이템에서 공백을 무시하고 매칭되는 아이템을 찾도록 변경