### PR TITLE
<fix> : refresh Token 이 cookie 로 반환

### DIFF
--- a/.github/workflows/gitaction.yaml
+++ b/.github/workflows/gitaction.yaml
@@ -5,7 +5,7 @@ on:
       - main
 env:
   MAJOR_VERSION: 1
-  MINOR_VERSION: 2
+  MINOR_VERSION: 3
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -5,32 +5,13 @@ import { useMainStore } from "@/store";
 export const useAuthStore = defineStore('auth', {
     state: () => ({
         accessToken: localStorage.getItem('accessToken'),
-        refreshToken: localStorage.getItem('refreshToken')
+        refreshToken: localStorage.getItem('refreshToken'),
+        isRefreshing: false,
     }),
     getters:{
         isAuthenticated: (state) => !!state.accessToken,
     },
     actions: {
-        async login(id, pwd){
-            
-            try {
-                const response = await axios.post(`${__API_PREFIX__}/api/alerter/auth/login`, {'username':id,'password': pwd})
-                const {accessToken, refreshToken, expireAt} = response.data
-                this.setTokens(accessToken, refreshToken)
-                return {success: true}
-            } catch (error){
-                if (error.response?.data?.code === 'AUTH_005') {
-                    return { 
-                        success: false, 
-                        message: error.response.data.message 
-                    }
-                }
-                return { 
-                    success: false, 
-                    message: '로그인에 실패했습니다.' 
-                }
-            }
-        },
         setTokens(accessToken, refreshToken){
             this.accessToken = accessToken,
             this.refreshToken = refreshToken
@@ -41,23 +22,6 @@ export const useAuthStore = defineStore('auth', {
         initialize() {
             if (this.accessToken) {
                 axios.defaults.headers.common['Authorization'] = `Bearer ${this.accessToken}`
-            }
-        },
-        async signup(id, pwd){
-            try{
-                await axios.post(`${__API_PREFIX__}/api/alerter/auth/register`, {'username':id,'password': pwd})
-            }catch(error){
-                console.error("SignUp Fail", error)
-                throw error
-            }
-        },
-        isTokenExpired(){
-            if(!this.accessToken) return true
-            try{
-                const payload = JSON.parse(atob(this.accessToken.split('.')[1]))
-                return Date.now() >= payload.exp * 1000
-            }catch(e){
-                return true
             }
         },
 
@@ -72,13 +36,20 @@ export const useAuthStore = defineStore('auth', {
             mainStore.clearRegisteredItems()
         },
         async renewToken(){
-            const payload =JSON.parse(atob(this.accessToken.split('.')[1]))
-            const refreshResponse = await axios.post(`${__API_PREFIX__}/api/alerter/auth/refresh`, {
-                "username" : payload.sub,
-                "refreshToken" : this.refreshToken
-            })
+            if(this.isRefreshing){
+                while (this.isRefreshing) {
+                    await new Promise(resolve => setTimeout(resolve, 10))
+                }
+                return // First refresh is done, use its result
+            }
+            this.isRefreshing = true
             try{
-                if(refreshResponse.status== HttpStatusCode.Ok){
+                const payload =JSON.parse(atob(this.accessToken.split('.')[1]))
+                const refreshResponse = await axios.post(`${__API_PREFIX__}/api/alerter/auth/refresh`, {
+                    "userId" : payload.sub,
+                    "refreshToken" : this.refreshToken
+                })
+                if(refreshResponse.status === HttpStatusCode.Ok){
                     const { accessToken, refreshToken} =  refreshResponse.data
                     this.setTokens(accessToken, refreshToken)
                 }else{
@@ -88,6 +59,8 @@ export const useAuthStore = defineStore('auth', {
             }catch(error){
                 console.error("Error occur in refreshing token")
                 this.logout()
+            }finally {
+                this.isRefreshing = false
             }
         }
     },

--- a/src/views/AuthCallBack.vue
+++ b/src/views/AuthCallBack.vue
@@ -3,9 +3,9 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/store/auth'
+import {onMounted} from 'vue'
+import {useRouter} from 'vue-router'
+import {useAuthStore} from '@/store/auth'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -15,7 +15,7 @@ onMounted(() => {
   const accessToken = params.get('accessToken')
   const refreshToken = params.get('refreshToken')
 
-  if (accessToken && refreshToken) {
+  if (accessToken) {
     authStore.setTokens(accessToken, refreshToken)
     router.push('/')
   } else {


### PR DESCRIPTION
- 이제 더이상 callback view 에서 localStorage 에 저장하지 않음.
- 아직 아래 버전 브라우저에서 동작중인 클라이언트를 위한 코드 유지
- 재발급 요청 body 의 필드 이름 변경 username => userId
- 액세스 토큰 발급시에 중복으로 reissue 요청 방지 auth.js